### PR TITLE
Cambio de comando ifconfig por ip

### DIFF
--- a/netkit-lab_conf_inicial/r1.startup
+++ b/netkit-lab_conf_inicial/r1.startup
@@ -1,1 +1,2 @@
-ifconfig eth0 10.4.11.30 netmask 255.255.255.0 broadcast 10.4.11.255 up
+ip addr add dev eth0 10.4.11.30/24
+ip link set dev eth0 up


### PR DESCRIPTION
Se cambia el laboratorio inicial para que use comando `ip` en lugar de `ifconfig` y sea consistente con los comandos mostrados en el [TP 1](http://www.labredes.unlu.edu.ar/sites/www.labredes.unlu.edu.ar/files/site/data/tyr/TyR-2019_tpl1-Configuracion_inicial.pdf).

Localmente levante los labos con `lstart` luego de aplicar el cambio, configure el host `pc1` con una IP de la misma red y pude hacer el ping `r1<--->pc1` sin problemas .